### PR TITLE
Remove `#include <pcl/ros/conversions.h>`

### DIFF
--- a/src/SnapMapICP.cpp
+++ b/src/SnapMapICP.cpp
@@ -33,8 +33,6 @@
 #include <sensor_msgs/PointCloud.h>
 #include <sensor_msgs/PointCloud2.h>
 #include <nav_msgs/OccupancyGrid.h>
-//for point_cloud::fromROSMsg
-#include <pcl/ros/conversions.h>
 #include <pcl_conversions/pcl_conversions.h>
 #include <sensor_msgs/point_cloud_conversion.h>
 #include <sensor_msgs/LaserScan.h>


### PR DESCRIPTION
This include is apparently not used in this file (catkin build compiles it without errors or relevant warnings),
the included file is deprecated in ros melodic and not present in ros noetic.
@sunava 